### PR TITLE
docs: expand README with setup, flashing, API and OTA notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,63 @@ options can be tuned via `menuconfig` or `sdkconfig.defaults`:
 
 Uploaded files are written in chunks to SPIFFS so large transfers do not require
 additional heap. Ensure that uploaded files fit within the 1 MB SPIFFS partition.
+
+## Toolchain setup
+
+1. Install the [ESP-IDF](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/index.html)
+   toolchain and export the environment:
+   ```bash
+   git clone --recursive https://github.com/espressif/esp-idf.git
+   ./esp-idf/install.sh esp32
+   . ./esp-idf/export.sh
+   ```
+2. Clone this repository into the `esp-idf` workspace and install the Python
+   requirements if prompted.
+
+## Flashing
+
+Connect the ESP32 over USB and run:
+
+```bash
+idf.py set-target esp32
+idf.py build
+idf.py -p <PORT> flash monitor
+```
+
+Replace `<PORT>` with the serial port used by your board.
+
+## Web interface
+
+On first boot the device starts a SoftAP named `ESP32_MIDI` with password
+`password`.  Visit [https://192.168.4.1](https://192.168.4.1) to open the
+configuration portal and enter Wi‑Fi credentials.  After connecting to the
+infrastructure network the same HTTPS interface allows uploading MIDI files and
+controlling playback.
+
+## HTTP API
+
+* `POST /upload` – multipart file upload stored under `/spiffs`.
+* `GET /track?file=<name>&track=<n>` – load track `n` from the uploaded file.
+* `GET /play`, `GET /pause`, `GET /stop` – playback control.
+* `POST /midi` – send raw MIDI bytes encoded as hexadecimal pairs.
+* `GET /ws` – WebSocket endpoint for streaming MIDI messages.
+* UDP port `5005` – accept raw MIDI packets over the network.
+
+All state‑changing requests require an `X-Auth-Token` header set to `midi123`.
+
+## Partitioning and OTA
+
+The custom partition table provides:
+
+| Name     | Size   | Notes                              |
+|----------|--------|------------------------------------|
+| `nvs`    | 16 KB  | Non‑volatile storage for settings. |
+| `phy_init` | 4 KB | Wi‑Fi calibration data.            |
+| `factory` | 2 MB  | Application slot.                  |
+| `storage` | 1 MB  | SPIFFS partition for MIDI files.   |
+
+Firmware updates can be uploaded using `POST /ota` with a multipart body.  The
+image is written to the application slot and the device reboots after a
+successful transfer.  An automatic OTA task periodically fetches firmware from
+`UPDATE_URL` (default one hour interval) and applies it when a newer version is
+available.


### PR DESCRIPTION
## Summary
- document toolchain installation and flashing steps
- describe web UI usage and HTTP/UDP API endpoints
- add partition table details and OTA update procedure

## Testing
- `idf.py --version` *(fails: command not found)*
- `cmake -S . -B build` *(fails: include could not find requested file)*


------
https://chatgpt.com/codex/tasks/task_e_6894675596e0832baefe7151e00a60e1